### PR TITLE
fix(mobile): adapt LLM settings dialog and PPT touch-action for Android

### DIFF
--- a/frontend/android/docs/配置文档.md
+++ b/frontend/android/docs/配置文档.md
@@ -36,7 +36,8 @@ http://10.0.2.2:8000/health
 
 ```bash
 cd frontend
-VITE_API_BASE_URL=http://10.0.2.2:8000 npm run build
+$env:VITE_API_BASE_URL="http://10.0.2.2:8000"
+npm run build
 npx cap sync android
 ```
 

--- a/frontend/src/components/SettingsDialog.vue
+++ b/frontend/src/components/SettingsDialog.vue
@@ -269,22 +269,17 @@ onMounted(() => {
     display: block;
     margin-top: 4px;
   }
-}
-</style>
 
-<style>
-@media (max-width: 768px) {
   .settings-llm-dialog {
     width: 95% !important;
     max-width: 95vw !important;
     margin: 5vh auto !important;
   }
-
-  .settings-llm-dialog .el-form-item {
+  .settings-llm-dialog :deep(.el-form-item) {
     display: block;
     margin-bottom: 18px;
   }
-  .settings-llm-dialog .el-form-item__label {
+  .settings-llm-dialog :deep(.el-form-item__label) {
     width: auto !important;
     text-align: left;
     padding: 0 0 4px 0;
@@ -292,7 +287,7 @@ onMounted(() => {
     height: auto;
     float: none;
   }
-  .settings-llm-dialog .el-form-item__content {
+  .settings-llm-dialog :deep(.el-form-item__content) {
     margin-left: 0 !important;
   }
 }

--- a/frontend/src/components/SettingsDialog.vue
+++ b/frontend/src/components/SettingsDialog.vue
@@ -3,6 +3,7 @@
     v-model="dialogVisible"
     title="LLM 配置设置"
     width="800px"
+    class="settings-llm-dialog"
     :before-close="handleClose"
   >
     <section class="provider-panel">
@@ -249,5 +250,50 @@ onMounted(() => {
   font-size: 12px;
   margin: -4px 0 8px 120px;
   word-break: break-word;
+}
+
+@media (max-width: 768px) {
+  .provider-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+  .provider-panel {
+    padding: 12px;
+  }
+  .sync-error {
+    margin-left: 0;
+  }
+  .sync-status {
+    margin-left: 0;
+    display: block;
+    margin-top: 4px;
+  }
+}
+</style>
+
+<style>
+@media (max-width: 768px) {
+  .settings-llm-dialog {
+    width: 95% !important;
+    max-width: 95vw !important;
+    margin: 5vh auto !important;
+  }
+
+  .settings-llm-dialog .el-form-item {
+    display: block;
+    margin-bottom: 18px;
+  }
+  .settings-llm-dialog .el-form-item__label {
+    width: auto !important;
+    text-align: left;
+    padding: 0 0 4px 0;
+    line-height: 1.4;
+    height: auto;
+    float: none;
+  }
+  .settings-llm-dialog .el-form-item__content {
+    margin-left: 0 !important;
+  }
 }
 </style>

--- a/frontend/src/modules/documents/components/PPTViewer/SlideViewer.vue
+++ b/frontend/src/modules/documents/components/PPTViewer/SlideViewer.vue
@@ -566,7 +566,7 @@ watch(() => props.currentSlideNumber, (newNumber) => {
 
   .slide-item {
     padding: 6px 0;
-    touch-action: pan-y;
+    touch-action: pan-x pan-y pinch-zoom;
   }
 
   .slide-image {


### PR DESCRIPTION
## 背景
本 PR 针对 `android-app` 分支(commit 5bfc48b "Add Android app mobile adaptation"),修复两个移动端体验问题 。

## 改动

### 1. LLM 配置弹窗适配小屏（SettingsDialog.vue）
- 弹窗 `width="800px"` 在 ≤768px 屏幕溢出 → 用 `@media` 覆盖为 95vw
- `el-form-item` 横向 120px label 把输入框挤到几乎不可用 → 移动端切换为 label 在上、input 在下,输入框占满宽度
- `.provider-header` flex 改纵向堆叠,避免标题和"刷新模型列表"按钮挤压
- 纯 CSS + `@media (max-width: 768px)` 实现,桌面端零影响

### 2. PPT 浏览触摸适配(SlideViewer.vue)
- `touch-action: pan-y` 禁止了横向滑动和双指缩放 → 改为 `pan-x pan-y pinch-zoom`
- 大尺寸 PPT 现在可以横向拖看,双指缩放恢复

## 测试
- Chrome DevTools 模拟 Pixel 5(393×851):弹窗 95% 宽 / label 上下排 / 横向滑动 / 缩放正常
- 桌面尺寸(>768px)下与改动前完全一致
- Android 模拟器实测可正常配置 LLM 和浏览 PPT

## 风险
两处改动都包在 `@media (max-width: 768px)` 块里,桌面端浏览器根本不解析,不影响 web 端行为。`!important` 用于覆盖 Element Plus 内联样式,作用域被 `.settings-llm-dialog` class 限定。