### PR TITLE
fix(mobile): use :global() for teleported el-dialog overrides

### DIFF
--- a/frontend/src/components/SettingsDialog.vue
+++ b/frontend/src/components/SettingsDialog.vue
@@ -270,16 +270,16 @@ onMounted(() => {
     margin-top: 4px;
   }
 
-  .settings-llm-dialog {
+  :global(.settings-llm-dialog) {
     width: 95% !important;
     max-width: 95vw !important;
     margin: 5vh auto !important;
   }
-  .settings-llm-dialog :deep(.el-form-item) {
+  :global(.settings-llm-dialog .el-form-item) {
     display: block;
     margin-bottom: 18px;
   }
-  .settings-llm-dialog :deep(.el-form-item__label) {
+  :global(.settings-llm-dialog .el-form-item__label) {
     width: auto !important;
     text-align: left;
     padding: 0 0 4px 0;
@@ -287,7 +287,7 @@ onMounted(() => {
     height: auto;
     float: none;
   }
-  .settings-llm-dialog :deep(.el-form-item__content) {
+  :global(.settings-llm-dialog .el-form-item__content) {
     margin-left: 0 !important;
   }
 }


### PR DESCRIPTION
## 背景
PR #14 (commit caea265 "refactor: use :deep() in scoped style") 引入了一个回归 bug：
LLM 配置弹窗的移动端样式在手机尺寸下不生效，弹窗仍然按 800px 渲染、表单 label 仍然横向占 120px,导致 Android 上无法正常填表。

## 根本原因
`<el-dialog>` 通过 `<teleport to="body">` 渲染到 `<body>` 之外，Vue 的 scoped `data-v-xxx` 属性无法传递到深层的 `.el-dialog` 元素。因此 PR #14 中的 `.settings-llm-dialog :deep(...)` 选择器，外层 `.settings-llm-dialog` 拿不到 scoped 属性,选择器整体不匹配，CSS 规则失效。

## 改动
将 4 条选择器从 `:deep()` 改为 `:global()`：

- `.settings-llm-dialog` → `:global(.settings-llm-dialog)`
- `.settings-llm-dialog :deep(.el-form-item)` → `:global(.settings-llm-dialog .el-form-item)`
- `.settings-llm-dialog :deep(.el-form-item__label)` → `:global(.settings-llm-dialog .el-form-item__label)`
- `.settings-llm-dialog :deep(.el-form-item__content)` → `:global(.settings-llm-dialog .el-form-item__content)`

`:global()` 在 `<style scoped>` 内显式声明全局规则,正是 Vue 提供的"在 scoped 块中精确开洞"的机制。这一写法在仓库中已有先例:
- `frontend/src/modules/chat/ChatView.vue:3824` (`.cheatsheet-dialog`)
- `frontend/src/modules/mindmap/components/MindMapViewer.vue:1076` (`.mindmap-fullscreen-dialog`)

## 验证
- Chrome DevTools 模拟 Pixel 5 (393×851)：弹窗 95vw 宽 / label 顶部排列 / provider-header 纵向堆叠
- 桌面尺寸 (>768px)：弹窗 800px / label 横向 120px,与 PR #14 改动前完全一致
- 改动仍然包在 `@media (max-width: 768px)` 内,桌面端零影响
